### PR TITLE
added retryCount to the order.Generate for certificate order finalization (Google Trust Services)

### DIFF
--- a/src/LettuceEncrypt/Internal/AcmeClient.cs
+++ b/src/LettuceEncrypt/Internal/AcmeClient.cs
@@ -123,7 +123,7 @@ internal class AcmeClient
     public async Task<CertificateChain> GetCertificateAsync(CsrInfo csrInfo, IKey privateKey, IOrderContext order)
     {
         _logger.LogAcmeAction("GenerateCertificate", order);
-        return await order.Generate(csrInfo, privateKey, _options.Value.PreferredChain);
+        return await order.Generate(csrInfo, privateKey, _options.Value.PreferredChain, retryCount: 5);
     }
 
     private static Exception MissingAccountContext() => new InvalidOperationException("Account wasn't initialized yet");


### PR DESCRIPTION
Fix for issue https://github.com/ArchonSystemsInc/LettuceEncrypt-Archon/issues/18, where AcmeClient.GetCertificateAsync calls order.Generate(csrInfo, privateKey, PreferredChain) without specifying retryCount, so it uses the Anvil default. On CAs that take longer to move an order from Processing to Valid after finalize (consistently reproducible with Google Trust Services, https://dv.acme-v02.api.pki.goog/directory), the default retry budget is exhausted before the order becomes valid, and Generate throws the generic Certify.ACME.Anvil.AcmeException: Fail to finalize order. 